### PR TITLE
Add slugified Lever data to document index for postings

### DIFF
--- a/Indexes/LeverPostingPartIndexHandler.cs
+++ b/Indexes/LeverPostingPartIndexHandler.cs
@@ -3,6 +3,7 @@ using Etch.OrchardCore.Lever.Api.Models.Dto;
 using Etch.OrchardCore.Lever.Models;
 using Newtonsoft.Json;
 using OrchardCore.Indexing;
+using OrchardCore.Liquid.Services;
 
 namespace Etch.OrchardCore.Lever.Indexes
 {
@@ -10,6 +11,7 @@ namespace Etch.OrchardCore.Lever.Indexes
     {
         public override Task BuildIndexAsync(LeverPostingPart part, BuildPartIndexContext context)
         {
+            var slugService = new SlugService();
             var options = context.Settings.ToOptions()
                 | DocumentIndexOptions.Analyze | DocumentIndexOptions.Store
                 ;
@@ -17,8 +19,11 @@ namespace Etch.OrchardCore.Lever.Indexes
             var posting = JsonConvert.DeserializeObject<Posting>(part.Data);
             context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Text", posting.Text, options);
             context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Team", posting.Categories.Team, options);
+            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Team.Slug", slugService.Slugify(posting.Categories.Team), options);
             context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Location", posting.Categories.Location, options);
+            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Location.Slug", slugService.Slugify(posting.Categories.Location), options);
             context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Commitment", posting.Categories.Commitment, options);
+            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Commitment.Slug", slugService.Slugify(posting.Categories.Commitment), options);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Currently I'm trying to do a query based on the free text but that isn't always working when the text I'm searching on contains spaces or special characters, searching on a slugified version seemed like a good fix, as they are already cleaned of anything that could cause an issue like that, and are easy to deal with in liquid too