### PR TITLE
Add filters for getting select options from an array of content items

### DIFF
--- a/Filters/CommitmentOptionsFilter.cs
+++ b/Filters/CommitmentOptionsFilter.cs
@@ -1,0 +1,42 @@
+﻿using Etch.OrchardCore.Lever.Utilities;
+using Fluid;
+using Fluid.Values;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.Liquid;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.Lever.Filters
+{
+    public class CommitmentOptionsFilter : ILiquidFilter
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public CommitmentOptionsFilter(
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        {
+            var commitments = new List<string>();
+            foreach (var value in input.Enumerate())
+            {
+                var commitment = await value.GetValueAsync("LeverPostingPart.Commitment", ctx);
+
+                if (!commitments.Any(x => x.Equals(commitment.ToStringValue(), System.StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    commitments.Add(commitment.ToStringValue());
+                }
+            }
+
+            
+            return new StringValue(StringUtils.GetOptions(commitments, _httpContextAccessor.HttpContext.Request.Query["commitment"].FirstOrDefault()));
+        }
+
+
+    }
+}

--- a/Filters/LocationOptionsFilter.cs
+++ b/Filters/LocationOptionsFilter.cs
@@ -23,17 +23,13 @@ namespace Etch.OrchardCore.Lever.Filters
         public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
         {
             var locations = new List<string>();
+
             foreach (var value in input.Enumerate())
             {
-                var location = await value.GetValueAsync("LeverPostingPart.Location", ctx);
-
-                if (!locations.Any(x => x.Equals(location.ToStringValue(), System.StringComparison.InvariantCultureIgnoreCase)))
-                {
-                    locations.Add(location.ToStringValue());
-                }
+                locations.Add((await value.GetValueAsync("LeverPostingPart.Location", ctx)).ToStringValue());
             }
 
-            return new StringValue(StringUtils.GetOptions(locations, _httpContextAccessor.HttpContext.Request.Query["location"].FirstOrDefault()));
+            return new StringValue(StringUtils.GetOptions(locations.Distinct().OrderBy(x => x).ToList(), _httpContextAccessor.HttpContext.Request.Query["location"].FirstOrDefault()));
         }
     }
 }

--- a/Filters/LocationOptionsFilter.cs
+++ b/Filters/LocationOptionsFilter.cs
@@ -1,0 +1,39 @@
+﻿using Etch.OrchardCore.Lever.Utilities;
+using Fluid;
+using Fluid.Values;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.Liquid;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.Lever.Filters
+{
+    public class LocationOptionsFilter : ILiquidFilter
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public LocationOptionsFilter(
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        {
+            var locations = new List<string>();
+            foreach (var value in input.Enumerate())
+            {
+                var location = await value.GetValueAsync("LeverPostingPart.Location", ctx);
+
+                if (!locations.Any(x => x.Equals(location.ToStringValue(), System.StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    locations.Add(location.ToStringValue());
+                }
+            }
+
+            return new StringValue(StringUtils.GetOptions(locations, _httpContextAccessor.HttpContext.Request.Query["location"].FirstOrDefault()));
+        }
+    }
+}

--- a/Filters/LocationOptionsFilter.cs
+++ b/Filters/LocationOptionsFilter.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Http;
 using OrchardCore.Liquid;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.Lever.Filters

--- a/Filters/TeamOptionsFilter.cs
+++ b/Filters/TeamOptionsFilter.cs
@@ -1,0 +1,39 @@
+﻿using Etch.OrchardCore.Lever.Utilities;
+using Fluid;
+using Fluid.Values;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.Liquid;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.Lever.Filters
+{
+    public class TeamOptionsFilter : ILiquidFilter
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public TeamOptionsFilter(
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        {
+            var teams = new List<string>();
+            foreach (var value in input.Enumerate())
+            {
+                var team = await value.GetValueAsync("LeverPostingPart.Team", ctx);
+
+                if (!teams.Any(x => x.Equals(team.ToStringValue(), System.StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    teams.Add(team.ToStringValue());
+                }
+            }
+
+            return new StringValue(StringUtils.GetOptions(teams, _httpContextAccessor.HttpContext.Request.Query["team"].FirstOrDefault()));
+        }
+    }
+}

--- a/Filters/TeamOptionsFilter.cs
+++ b/Filters/TeamOptionsFilter.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Http;
 using OrchardCore.Liquid;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.Lever.Filters
@@ -14,8 +13,7 @@ namespace Etch.OrchardCore.Lever.Filters
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public TeamOptionsFilter(
-            IHttpContextAccessor httpContextAccessor)
+        public TeamOptionsFilter(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor;
         }
@@ -23,17 +21,13 @@ namespace Etch.OrchardCore.Lever.Filters
         public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
         {
             var teams = new List<string>();
+
             foreach (var value in input.Enumerate())
             {
-                var team = await value.GetValueAsync("LeverPostingPart.Team", ctx);
-
-                if (!teams.Any(x => x.Equals(team.ToStringValue(), System.StringComparison.InvariantCultureIgnoreCase)))
-                {
-                    teams.Add(team.ToStringValue());
-                }
+                teams.Add((await value.GetValueAsync("LeverPostingPart.Team", ctx)).ToStringValue());
             }
 
-            return new StringValue(StringUtils.GetOptions(teams, _httpContextAccessor.HttpContext.Request.Query["team"].FirstOrDefault()));
+            return new StringValue(StringUtils.GetOptions(teams.Distinct().OrderBy(x => x).ToList(), _httpContextAccessor.HttpContext.Request.Query["team"].FirstOrDefault()));
         }
     }
 }

--- a/Indexes/LeverPostingPartIndexHandler.cs
+++ b/Indexes/LeverPostingPartIndexHandler.cs
@@ -16,9 +16,9 @@ namespace Etch.OrchardCore.Lever.Indexes
 
             var posting = JsonConvert.DeserializeObject<Posting>(part.Data);
             context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Text", posting.Text, options);
-            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Team", posting.Categories.Team, options);
-            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Location", posting.Categories.Location, options);
-            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Commitment", posting.Categories.Commitment, options);
+            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Team", posting.Categories.Team, DocumentIndexOptions.Store);
+            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Location", posting.Categories.Location, DocumentIndexOptions.Store);
+            context.DocumentIndex.Set($"{nameof(LeverPostingPart)}.Commitment", posting.Categories.Commitment, DocumentIndexOptions.Store);
 
             return Task.CompletedTask;
         }

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Etch.OrchardCore.Lever.Api.Models.Dto;
 using Etch.OrchardCore.Lever.Api.Services;
 using Etch.OrchardCore.Lever.Drivers;
+using Etch.OrchardCore.Lever.Filters;
 using Etch.OrchardCore.Lever.Indexes;
 using Etch.OrchardCore.Lever.Models;
 using Etch.OrchardCore.Lever.Services;
@@ -13,6 +14,7 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Indexing;
+using OrchardCore.Liquid;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Settings;
@@ -44,6 +46,11 @@ namespace Etch.OrchardCore.Lever
             services.AddScoped<IDisplayDriver<ISite>, LeverSettingsDisplayDriver>();
             services.AddScoped<IContentPartIndexHandler, LeverPostingPartIndexHandler>();
             services.AddScoped<IDataMigration, Migrations>();
+
+            services.AddLiquidFilter<CommitmentOptionsFilter>("lever_commitment_options");
+            services.AddLiquidFilter<LocationOptionsFilter>("lever_location_options");
+            services.AddLiquidFilter<TeamOptionsFilter>("lever_team_options");
+
             services.AddHttpClient();
         }
     }

--- a/Utilities/StringUtils.cs
+++ b/Utilities/StringUtils.cs
@@ -3,37 +3,22 @@ using System.Text;
 
 namespace Etch.OrchardCore.Lever.Utilities
 {
-    public class StringUtils
+    public static class StringUtils
     {
         public static string GetOptions(IList<string> items, string selectedValue)
         {
-            StringBuilder bld = new StringBuilder();
-            bld.Append("<option value=\"\">All</option>\n");
+            var builder = new StringBuilder();
+            builder.Append("<option value=\"\">All</option>\n");
+
             for (int i = 0; i < items.Count; ++i)
             {
-                var value = GetOptionValue(items[i]);
-
-                bld.Append(string.Format("<option value=\"{0}\"{1}>{2}</option>\n",
-                                value,
-                                !string.IsNullOrEmpty(selectedValue) && selectedValue == value ? " selected=\"selected\"" : "",
+                builder.Append(string.Format("<option value=\"{0}\"{1}>{2}</option>\n",
+                                items[i],
+                                !string.IsNullOrEmpty(selectedValue) && selectedValue == items[i] ? " selected=\"selected\"" : "",
                                 items[i]));
             }
 
-            return bld.ToString();
-        }
-
-        public static string GetOptionValue(string name)
-        {
-            HashSet<char> removeChars = new HashSet<char>("?&^$#@!()+-,:;<>’\'-_*");
-            StringBuilder result = new StringBuilder(name.Length);
-            foreach (char c in name.ToLower())
-            {
-                if (!removeChars.Contains(c))
-                {
-                    result.Append(c);
-                }
-            }
-            return result.ToString();
+            return builder.ToString();
         }
     }
 }

--- a/Utilities/StringUtils.cs
+++ b/Utilities/StringUtils.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace Etch.OrchardCore.Lever.Utilities
+{
+    public class StringUtils
+    {
+        public static string GetOptions(IList<string> items, string selectedValue)
+        {
+            StringBuilder bld = new StringBuilder();
+            bld.Append("<option value=\"\">All</option>\n");
+            for (int i = 0; i < items.Count; ++i)
+            {
+                var value = GetOptionValue(items[i]);
+
+                bld.Append(string.Format("<option value=\"{0}\"{1}>{2}</option>\n",
+                                value,
+                                !string.IsNullOrEmpty(selectedValue) && selectedValue == value ? " selected=\"selected\"" : "",
+                                items[i]));
+            }
+
+            return bld.ToString();
+        }
+
+        public static string GetOptionValue(string name)
+        {
+            HashSet<char> removeChars = new HashSet<char>("?&^$#@!()+-,:;<>’\'-_*");
+            StringBuilder result = new StringBuilder(name.Length);
+            foreach (char c in name.ToLower())
+            {
+                if (!removeChars.Contains(c))
+                {
+                    result.Append(c);
+                }
+            }
+            return result.ToString();
+        }
+    }
+}


### PR DESCRIPTION
I've created three new filters that take an array of content items as an array, and parse them to give you a string of `<option>` html tags back.

An example use for this is when trying to get the teams for all lever postings within the CMS:

```
{% assign allPostings = Queries.AllLeverPostings | query %}

<select id="location">
    {{ allPostings | lever_location_options | raw }}
</select>
```

Still need to work on getting the current request context, so if one of these is selected then we should preselect it where the options are built.

The values put into the `value` of the `<option>` tags are also not what is stored on the index, as that gets analysed, so I'm not sure of a solution to this

If you want an example of this in use, shoot me a DM, as its currently only on a private project