### PR TITLE
Add missing ViewModels Template Context so can access them in liquid

### DIFF
--- a/Controllers/ApplyController.cs
+++ b/Controllers/ApplyController.cs
@@ -76,9 +76,13 @@ namespace Etch.OrchardCore.Lever.Controllers
                 if (result != null)
                 {
                     ModelState.AddModelError("error", result.Error);
+
+                    // If there is a validation error from API
+                    // we send the user back to the page
+                    return new RedirectResult(referer);
                 }
 
-                return new RedirectResult(referer);
+                return new RedirectResult($"{settings.SuccessUrl}");
             }
 
             return new RedirectResult($"{settings.SuccessUrl}?applicationId={result.ApplicationId}&contentItemId={contentItem.ContentItemId}" ?? "/");

--- a/Startup.cs
+++ b/Startup.cs
@@ -27,6 +27,8 @@ namespace Etch.OrchardCore.Lever
         static Startup()
         {
             TemplateContext.GlobalMemberAccessStrategy.Register<LeverPostingPartViewModel>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<LeverPostingApplyViewModel>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<CustomQuestions>();
             TemplateContext.GlobalMemberAccessStrategy.Register<Posting>();
             TemplateContext.GlobalMemberAccessStrategy.Register<PostingCategories>();
         }


### PR DESCRIPTION
- Also changed the redirect for API server error (Due to the form issue) to take user to success URL as we fire an event and store the user’s data before the user gets there.