### PR TITLE
Add formatting to lever posts sent to MVC

### DIFF
--- a/Etch.OrchardCore.Lever.csproj
+++ b/Etch.OrchardCore.Lever.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.2.10-rc2</Version>
+    <Version>0.2.11-rc2</Version>
     <PackageId>Etch.OrchardCore.Lever</PackageId>
     <Title>Lever</Title>
     <Authors>Etch</Authors>

--- a/Feeds/Services/LeverPostingFeedService.cs
+++ b/Feeds/Services/LeverPostingFeedService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -45,6 +45,7 @@ namespace Etch.OrchardCore.Lever.Services
                 var job = new XElement("job");
                 var jobInfo = new XElement("job_info");
                 var location = new XElement("location");
+                var contact = new XElement("contact");
 
                 var postingPart = JsonConvert.DeserializeObject<Posting>(posting.GetLeverPostingPart().Data);
 
@@ -59,8 +60,11 @@ namespace Etch.OrchardCore.Lever.Services
                 location.Add(new XElement("state", new XCData(settings.GetSteteValue() ?? "")));
                 location.Add(new XElement("function", new XCData(settings.GetFunctionValue() ?? "")));
 
+                contact.Add(new XElement("apply_url", new XCData(postingPart.ApplyUrl)));
+
                 job.Add(jobInfo);
                 job.Add(location);
+                job.Add(contact);
                 jobs.Add(job);
             }
 

--- a/Feeds/Services/LeverPostingFeedService.cs
+++ b/Feeds/Services/LeverPostingFeedService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -51,8 +51,8 @@ namespace Etch.OrchardCore.Lever.Services
 
                 job.Add(new XElement("site_id", new XCData(settings.GetSiteIdValue() ?? "")));
 
-                jobInfo.Add(new XElement("company", new XCData(settings.GetSiteNameValue())));
-                jobInfo.Add(new XElement("description", new XCData($"{postingPart.DescriptionPlain} {GetLists(postingPart.Lists)} {postingPart.AdditionalPlain}")));
+                jobInfo.Add(new XElement("company", new XCData(settings.GetSiteNameValue() ?? "")));
+                jobInfo.Add(new XElement("description", new XCData($"{CleanDescription(postingPart.DescriptionPlain)} {GetLists(postingPart.Lists)} {CleanDescription(postingPart.Additional)}")));
                 jobInfo.Add(new XElement("name", new XCData(postingPart.Id)));
                 jobInfo.Add(new XElement("position", new XCData(postingPart.Text)));
 
@@ -83,15 +83,15 @@ namespace Etch.OrchardCore.Lever.Services
             foreach (var list in lists)
             {
                 text = $"{text} {list.Text} {Environment.NewLine}";
-                text = $"{text} {ReplaceLists(list.Content)} {Environment.NewLine}{Environment.NewLine}";
+                text = $"{text} {list.Content} {Environment.NewLine}{Environment.NewLine}";
             }
 
             return text;
         }
 
-        private string ReplaceLists(string text)
+        private string CleanDescription(string text)
         {
-            return Regex.Replace(text.Replace("</li>", Environment.NewLine), "<[^>]*(>|$)", string.Empty);
+            return text.Replace(Environment.NewLine, "<br />").Replace("&nbsp;", "");
         }
 
         #endregion

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -3,7 +3,7 @@ using OrchardCore.Modules.Manifest;
 [assembly: Module(
     Author = "Etch",
     Name = "Lever",
-    Version = "0.2.10",
+    Version = "0.2.11",
     Website = "https://etchuk.com"
 )]
 

--- a/Migrations/create.recipe.json
+++ b/Migrations/create.recipe.json
@@ -4,7 +4,7 @@
   "description": "Provides lever search.",
   "author": "Etch",
   "website": "https://etchuk.com",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "issetuprecipe": false,
   "categories": [
     "search",

--- a/Migrations/custom-settings.recipe.json
+++ b/Migrations/custom-settings.recipe.json
@@ -4,7 +4,7 @@
     "description": "Provides lever custom settings for feeds.",
     "author": "Etch",
     "website": "https://etchuk.com",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "issetuprecipe": false,
     "categories": ["lever"],
     "tags": ["lever"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.lever",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "description": "Module for Orchard Core providing integration with Lever.",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Currently MVC job postings from us have a lack of formatting and do not have the apply URL on them. I've changed the feed we provide to MVC to keep formatting we get from Lever, and added in a new contact section for each job.

There may be more formatting to apply, but this should be a better starting point than what we have right now